### PR TITLE
Fixed updateNPCModelFlags

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -95,9 +95,6 @@ async function updateNPCModelFlags(actor, updateData) {
          updatedFlags.willSave.value = actor.saves.will.dc.value;
          // Repopulate other values as needed...
 
-         // TODO: setFlag is changing the internal data of the actor so it is triggering the updateActor.
-         // TODO: Come up with some logic that will detect if the update has happened and skip that line.
-
          if (!isEqual(existingFlags, updatedFlags)) {
             await actor.setFlag("fvtt-knowledge-recalled-pf2e", "npcFlags", updatedFlags);
             console.log("Flags updated:", updatedFlags);

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,6 @@ Hooks.on("ready", () =>
    {
       addNPCtoGlobalArray(element);
    }
-   //console.log("npcActors: ", npcActors);
    KnowledgeRecalled._onReady(npcActors);
    const KnowledgeRecalledActors = KnowledgeRecalled.getActors();
    console.log("KnowledgeRecalledActors: ", KnowledgeRecalledActors);
@@ -59,7 +58,6 @@ async function initNPCModel(actor)
       console.error("Error initializing NPCModel: ", error);
    }
 }
-
 async function updateNPCModelFlags(actor)
 {
    try
@@ -118,31 +116,3 @@ async function addNPCtoGlobalArray(encounter)
 
 }
 
-
-// async function getNPCActorsFromEncounters()
-// {
-//    const encounters = await game.combats;
-//    console.log(encounters);
-//    let activeEncounter = [];
-//    activeEncounter = encounters.find((encounter) => encounter.active === true);
-//
-//    if (!activeEncounter)
-//    {
-//       console.log("No active encounter found.");
-//       return [];
-//    }
-//
-//    const npcCombatants = activeEncounter.filter(
-//     (combatant) => combatant.actor.data.type === "npc"
-//    );
-//
-//    const npcActors = [];
-//
-//    for (const npcCombatant of npcCombatants)
-//    {
-//       const foundryNPC = npcCombatant.actor;
-//       npcActors.push(foundryNPC);
-//    }
-//
-//    return npcActors;
-// }

--- a/src/index.js
+++ b/src/index.js
@@ -44,6 +44,15 @@ Hooks.on('createActor', (actor, options, userId) =>
 
    }
 });
+Hooks.on("updateActor", async (actor, updateData) => {
+   // Check if the update is relevant to the NPC flags
+   console.log("Updating Actor");
+   if (updateData?.flags?.["fvtt-knowledge-recalled-pf2e"]?.npcFlags) {
+      // Call the function to update the NPC model flags
+      await updateNPCModelFlags(actor);
+   }
+});
+
 
 async function initNPCModel(actor)
 {
@@ -59,61 +68,87 @@ async function initNPCModel(actor)
       console.error("Error initializing NPCModel: ", error);
    }
 }
+// Function to update the NPC model flags
 async function updateNPCModelFlags(actor)
 {
    try
    {
-      const KRNPC = await new NPCModel(actor);
-      await KRNPC.checkForChangesOnUpdate(actor);
-      KRNPC.processValues();
-      console.log("Knowledge Recalled NPC: ", KRNPC);
+      const existingFlags = actor.getFlag("fvtt-knowledge-recalled-pf2e", "npcFlags");
+      if (existingFlags)
+      {
+         // Exclude visibility properties from the existingFlags object
+         const updatedFlags = Object.entries(existingFlags).reduce((flags, [key, value]) =>
+         {
+            if (!key.endsWith(".visibility"))
+            {
+               flags[key] = value;
+            }
+            return flags;
+         }, {});
+
+         // Repopulate the values that have path declarations
+         updatedFlags.baseCharacterInfo.name = actor.name;
+         updatedFlags.baseCharacterInfo.creatureType = actor.system.details.creatureType;
+         updatedFlags.baseCharacterInfo.alliance = actor.alliance;
+         updatedFlags.baseCharacterInfo.actorImg = actor.img;
+         updatedFlags.baseCharacterInfo.description = actor.description;
+         updatedFlags.rarity.value = actor.rarity;
+         updatedFlags.privateInfo.privateDescription = actor.system.details.privateNotes;
+         updatedFlags.privateInfo.CR = actor.level;
+
+         updatedFlags.armorClass.value = actor.attributes.ac.base;
+         updatedFlags.fortSave.value = actor.saves.fortitude.dc.value;
+         updatedFlags.refSave.value = actor.saves.reflex.dc.value;
+         updatedFlags.willSave.value = actor.saves.will.dc.value;
+         // Repopulate other values as needed...
+
+         await actor.setFlag("fvtt-knowledge-recalled-pf2e", "npcFlags", updatedFlags);
+         console.log("Flags updated:", updatedFlags);
+      }
+      else
+      {
+         console.log("No existing flags found. Initializing flags...");
+         // Initialize flags if necessary
+         // ...
+      }
    }
    catch (error)
    {
-      console.error("Error initializing NPCModel: ", error);
-   }
-
-
-   /*Hooks.on('updateActor', (actor, options, userId) =>
-   {
-      // Check if the actor is an NPC
-      if (actor.type === 'npc')
-      {
-         updateNPCModelFlags(actor).then((r) => console.log(r));
-      }
-   });*/
-
-
-   function getActiveEncounters()
-   {
-      const encounters = game.combats.combats;
-      let activeEncounters = [];
-      activeEncounters = encounters.filter((encounter) => encounter.active === true);
-      if (!activeEncounters)
-      {
-         console.log("No active encounter found.");
-         return [];
-      }
-      return activeEncounters;
-   }
-
-   async function addNPCtoGlobalArray(encounter)
-   {
-      const npcCombatants = encounter.turns;
-      npcCombatants.forEach((actor) =>
-      {
-         if (
-          !npcActors.find((npcActor) =>
-          {
-             return npcActor.actorId === actor.actorId;
-          }) &&
-          actor.isNPC === true
-         )
-         {
-            const newActor = game.actors.get(actor.actorId);
-            npcActors.push(newActor);
-         }
-      });
+      console.error("Error updating NPC flags:", error);
    }
 }
+
+
+function getActiveEncounters()
+{
+   const encounters = game.combats.combats;
+   let activeEncounters = [];
+   activeEncounters = encounters.filter((encounter) => encounter.active === true);
+   if (!activeEncounters)
+   {
+      console.log("No active encounter found.");
+      return [];
+   }
+   return activeEncounters;
+}
+
+async function addNPCtoGlobalArray(encounter)
+{
+   const npcCombatants = encounter.turns;
+   npcCombatants.forEach((actor) =>
+   {
+      if (
+       !npcActors.find((npcActor) =>
+       {
+          return npcActor.actorId === actor.actorId;
+       }) &&
+       actor.isNPC === true
+      )
+      {
+         const newActor = game.actors.get(actor.actorId);
+         npcActors.push(newActor);
+      }
+   });
+}
+
 

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,7 @@ Hooks.on("ready", () =>
    KnowledgeRecalled._onReady(npcActors);
    const KnowledgeRecalledActors = KnowledgeRecalled.getActors();
    console.log("KnowledgeRecalledActors: ", KnowledgeRecalledActors);
+
 });
 
 Hooks.on('createActor', (actor, options, userId) =>

--- a/src/models/ActorModel.js
+++ b/src/models/ActorModel.js
@@ -12,263 +12,112 @@ export default class NPCActor extends Actor
       this._data = data;
    }
 
-   static get defaultOptions()
-   {
-      return mergeObject(super.defaultOptions, {
-         visibility: false
-      });
-   }
-
-  //  actorID = "";
-  //  isNPCHostile = Boolean;
-  //  privateInfo = {
-  //     privateDescription: String,
-  //     CR: Number,
-  //     visibility: false
-  //   };
-  //  baseCharacterInfo = {
-  //     name: String,
-  //     actorImg: String,
-  //     description: String,
-  //     visibility: false
-  //  };
-  //  rarity = {
-  //     value: String,
-  //     visibility: false
-  //  };
-  //  traits = [
-  //        {
-  //           trait: String,
-  //           visibility: false
-  //        }
-  //  ];
-  //
-  //  armorClass = {
-  //     value: Number,
-  //     visibility: false,
-  //     beforeDC: Number,
-  //     afterDC: Number
-  //  };
-
-  //  attacks = [
-  //        {
-  //           name: String,
-  //           description: String,
-  //           type: String,
-  //           visibility: false
-  //        }
-  //  ];
-  //  passiveAbilities = [
-  //        {
-  //           name: String,
-  //           description: String,
-  //           visibility: false
-  //        }
-  //     ];
-
-  //
-  //  getBaseCharacterInfo()
-  //  {
-  //     // designed to read the characters queried from game.actors.get(actorID)
-  //     return {
-  //        name: self.name,
-  //        actorImg: self.actorImg,
-  //        rarity: self.rarity,
-  //        armorValue: self.armorClass.value
-  //     }
-  //  }
-
-  //ctionLength = self.actions.length;
-   //   //      for (let i = 0; i < actionLength; i++)
-   //   //      {
-   //   //         const action = self.actions[i];
-   //   //         if (action.actionType === "action")
-   //   //         {
-   //   //            this.abilities.push({
-   //   //               name: action.name,
-   //   //               description: action.system.description,
-   //   //               visibility: false
-   //   //            });
-   //   //         }
-   //   //         else if (action.actionType === "passive")
-   //   //         {
-   //   //              this.passiveAbilities.push({
-   //   //                 name: action.name,
-   //   //                 description: action.system.description,
-   //   //                 visibility: false
-   //   //              });
-   //   //         }
-   //   //         else
-   //   //         {
-   //   //              console.log("DEBUG FLAG, DETERMINE action type and create a rule");
-   //   //         }
-   //   //      }
-   //   //  }
-   //   //
-   //
-   //   //
-   //
-   //   //
-   //
-   //
-   //   //  }
-   //   //
-   //   //
-   //   //  getAttacks()  //still working on
-   //   //  {
-   //   //     const actionsLength = this.actions.length;
-   //   //     for (let i = 0; i < actionsLength; i++)
-   //   //     {
-   //   //        const action = this.actions[i];
-   //   //        switch (action.attackRollType)
-   //   //        {
-   //   //           case "PF2E.NPCAttackMelee":
-   //   //              this.attacks.push({
-   //   //                 name: action.label,
-   //   //                 description: action.description,
-   //   //                 type: "melee",
-   //   //                 visibility: false
-   //   //              });
-   //   //              break;
-   //   //           case "PF2E.NPCAttackRanged":
-   //   //              this.attacks.push({
-   //   //                 name: action.label,
-   //   //                 description: action.description,
-   //   //                 type: "range",
-   //   //                 visibility: false
-   //   //              });
-   //   //              break;
-   //   //           default:
-   //   //              this.attacks.push({
-   //   //                 name: action.label,
-   //   //                 description: action.description,
-   //   //                 type: "no-match; debug",
-   //   //                 visibility: true
-   //   //              });
-   //   //              console.log("DEBUG FLAG, DETERMINE attack type and create a rule")
-   //   //        }
-   //   //     }
-   //   //     return this.attacks;
-   //   //  }
-   //   //
-   //   //  getTraits()
-   //   //  {
-   //   //     // this.isNPCHostile = data.system.traits.attitude.value;
-   //   //
-   //   //     const traitLength = self.traits.value.length;
-   //   //     for (let i = 0; i < traitLength; i++)
-   //   //     {
-   //   //        const trait = self.traits.value[i];
-   //   //        this.traits.push({
-   //   //           trait,
-   //   //           visibility: false
-   //   //        });
-   //   //     }
-   //   //     return this.traits;
-   //   //  }
-   //   //
-   //   //
-   //   //  //getCreatureTraits()
-   //
-   //    // static _onReady()
-   //    // {
-   //    //
-   //    //   KnowledgeRecalled.NPCActor = new NPCActor();
-   //    // }
-  //  getActions()
-  //  {
-  //      const a
-
    /**
     * Get data required for template
     */
-   getData() 
-{
-      const { name, saves, alliance, rarity, description, traits, level, img, system } = this._data;
-      const { attributes } = system;
-      const { fortitude, reflex, will } = saves?.dc || {};
-
+   getData()
+   {
+      const { name, saves, alliance, rarity, description,
+               traits, level, system, img } = this._data;
+      const { abilities, attributes } = system;
+      const { privateNotes } = system.details;
       const savesDS = {
          value: saves,
          beforeDC: Number,
          afterDC: Number,
          isVisible: false,
       };
-
-      const armorClass = {
-         base: attributes?.ac?.base,
-         value: attributes?.ac?.value,
-         modifier: attributes?.ac?.totalModifier,
+      const fortitudeSaveDS = {
+         value: saves.fortitude.dc.value,
          beforeDC: Number,
          afterDC: Number,
          isVisible: false,
       };
-
-      const hp = {
-         base: attributes?.hp?.base,
-         max: attributes?.hp?.max,
-         negativeHealing: attributes?.hp?.negativeHealing,
-         temp: attributes?.hp?.temp,
-         value: attributes?.hp?.value,
-         modifier: attributes?.hp?.totalModifier,
+      const reflexSaveDS = {
+         value: saves.reflex.dc.value,
          beforeDC: Number,
          afterDC: Number,
          isVisible: false,
       };
-
-      const immunities = {
-         type: attributes?.immunities,
-         value: attributes?.immunities?.value,
-         modifier: attributes?.immunities?.totalModifier,
+      const willSaveDS = {
+         value: saves.will.dc.value,
          beforeDC: Number,
          afterDC: Number,
          isVisible: false,
       };
+      const attributesDS = {
+         value: system.attributes,
+         beforeDC: Number,
+         afterDC: Number,
+         isVisible: false,
+      };
+      const armorClassDS = {
+         base: attributes.ac.base,
+         value: attributes.ac.value,
+         modifier: attributes.ac.totalModifier,
+         beforeDC: Number,
+         afterDC: Number,
+         isVisible: false,
+      };
+      const hpDS = {
+         base: attributes.hp.base,
+         max: attributes.hp.max,
+         negativeHealing: attributes.hp.negativeHealing,
+         temp: attributes.hp.temp,
+         value: attributes.hp.value,
+         modifier: attributes.hp.totalModifier,
+         beforeDC: Number,
+         afterDC: Number,
+         isVisible: false,
 
-      const resistances = attributes?.resistances || [];
-      const weaknesses = attributes?.weaknesses || [];
+      };
+      const immunitiesDS = {
+         type: attributes.immunities,
+         value: attributes.immunities.value,
+         modifier: attributes.immunities.totalModifier,
+         beforeDC: Number,
+         afterDC: Number,
+         isVisible: false,
+      };
+      const resistancesDS = {
+         type: attributes.resistances,
+         value: attributes.resistances.value,
+         modifier: attributes.resistances.totalModifier,
+         beforeDC: Number,
+         afterDC: Number,
+         isVisible: false,
+      };
+      const weaknessesDS = {
+         type: attributes.weaknesses,
+         value: attributes.weaknesses.value,
+         modifier: attributes.weaknesses.totalModifier,
+         beforeDC: Number,
+         afterDC: Number,
+         isVisible: false
+      };
 
       return {
          name,
          savesDS,
-         fortitude: {
-            value: fortitude?.value,
-            beforeDC: Number,
-            afterDC: Number,
-            isVisible: false,
-         },
-         reflex: {
-            value: reflex?.value,
-            beforeDC: Number,
-            afterDC: Number,
-            isVisible: false,
-         },
-         will: {
-            value: will?.value,
-            beforeDC: Number,
-            afterDC: Number,
-            isVisible: false,
-         },
+         fortitudeSaveDS,
+         reflexSaveDS,
+         willSaveDS,
          img,
          attributes,
-         hp,
-         immunities,
+         hpDS,
+         immunitiesDS,
          description,
-         abilities: system.abilities,
+         abilities,
          level,
-         traits,
-         privateDescription: system.details?.privateNotes,
-         armorClass,
-         attributesDS: {
-            value: system.attributes,
-            beforeDC: Number,
-            afterDC: Number,
-            isVisible: false,
-         },
-         resistances,
-         weaknesses,
+         privateNotes,
+         armorClassDS,
+         attributesDS,
+         resistancesDS,
+         weaknessesDS,
          alliance,
          rarity,
+         traits,
+
       };
    }
 

--- a/src/models/KnowledgeRecalled.js
+++ b/src/models/KnowledgeRecalled.js
@@ -4,7 +4,7 @@ import NPCActor from "./ActorModel.js";
 export default class KnowledgeRecalled extends Application
 {
    static NPCActors = [];
-   constructor(FoundryActors) 
+   constructor(FoundryActors)
    {
       super();
       console.log("Storing NPC Actors");
@@ -13,10 +13,7 @@ export default class KnowledgeRecalled extends Application
       {
          KnowledgeRecalled.NPCActors.push(new NPCActor(element).getData());
       }
-      //console.log("Displaying NPCActors: ", KnowledgeRecalled.NPCActors);
-     // console.log("Displaying first actor: ", NPCActors[0].getData());
    }
-
 
    static _onReady(listOfFoundryActors)
    {

--- a/src/models/KnowledgeRecalled.js
+++ b/src/models/KnowledgeRecalled.js
@@ -1,4 +1,5 @@
 import NPCActor from "./ActorModel.js";
+import NPCModel from "./NPCModel.js";
 
 // eslint-disable-next-line no-unused-vars
 export default class KnowledgeRecalled extends Application
@@ -11,7 +12,7 @@ export default class KnowledgeRecalled extends Application
 
       for (const element of FoundryActors)
       {
-         KnowledgeRecalled.NPCActors.push(new NPCActor(element).getData());
+         KnowledgeRecalled.NPCActors.push(new NPCModel(element));
       }
    }
 

--- a/src/models/NPCModel.js
+++ b/src/models/NPCModel.js
@@ -288,49 +288,49 @@ export default class NPCModel
          console.error(`Invalid visibility property: ${propertyPath}`);
       }
    }
-   checkForChangesOnUpdate(actor)
-   {
-   const existingFlags = this.actor.getFlag("fvtt-knowledge-recalled-pf2e", "npcFlags");
-   if (existingFlags)
-   {
-      // Exclude visibility properties from the existingFlags object
-      const updatedFlags = Object.entries(existingFlags).reduce((flags, [key, value]) =>
-      {
-         if (!key.endsWith(".visibility"))
-         {
-            flags[key] = value;
-         }
-         return flags;
-      }, {});
-
-      // Repopulate the values that have path declarations
-      updatedFlags.baseCharacterInfo.name = actor.name;
-      updatedFlags.baseCharacterInfo.creatureType = actor.system.details.creatureType;
-      updatedFlags.baseCharacterInfo.alliance = actor.alliance;
-      updatedFlags.baseCharacterInfo.actorImg = actor.img;
-      updatedFlags.baseCharacterInfo.description = actor.description;
-      updatedFlags.rarity.value = actor.rarity;
-      updatedFlags.privateInfo.privateDescription = actor.system.details.privateNotes;
-      updatedFlags.privateInfo.CR = actor.level;
-      // need to do traits once this works
-
-      updatedFlags.armorClass.value = actor.attributes.ac.base;
-      updatedFlags.fortSave.value = actor.saves.fortitude.dc.value;
-      updatedFlags.refSave.value = actor.saves.reflex.dc.value;
-      updatedFlags.willSave.value = actor.saves.will.dc.value;
-      // Repopulate other values as needed...
-
-      this.flags = updatedFlags;
-      if (this.actor.type === "npc")
-      {
-         this.actor.setFlag("fvtt-knowledge-recalled-pf2e", "npcFlags", this.flags)
-         .then(() => this.processValues())
-         .catch((error) => console.error("Failed to set flags:", error));
-      }
-   }
-      else
-      {
-         this.initializeFlags();
-      }
-   }
+   // checkForChangesOnUpdate(actor)
+   // {
+   // const existingFlags = this.actor.getFlag("fvtt-knowledge-recalled-pf2e", "npcFlags");
+   // if (existingFlags)
+   // {
+   //    // Exclude visibility properties from the existingFlags object
+   //    const updatedFlags = Object.entries(existingFlags).reduce((flags, [key, value]) =>
+   //    {
+   //       if (!key.endsWith(".visibility"))
+   //       {
+   //          flags[key] = value;
+   //       }
+   //       return flags;
+   //    }, {});
+   //
+   //    // Repopulate the values that have path declarations
+   //    updatedFlags.baseCharacterInfo.name = actor.name;
+   //    updatedFlags.baseCharacterInfo.creatureType = actor.system.details.creatureType;
+   //    updatedFlags.baseCharacterInfo.alliance = actor.alliance;
+   //    updatedFlags.baseCharacterInfo.actorImg = actor.img;
+   //    updatedFlags.baseCharacterInfo.description = actor.description;
+   //    updatedFlags.rarity.value = actor.rarity;
+   //    updatedFlags.privateInfo.privateDescription = actor.system.details.privateNotes;
+   //    updatedFlags.privateInfo.CR = actor.level;
+   //    // need to do traits once this works
+   //
+   //    updatedFlags.armorClass.value = actor.attributes.ac.base;
+   //    updatedFlags.fortSave.value = actor.saves.fortitude.dc.value;
+   //    updatedFlags.refSave.value = actor.saves.reflex.dc.value;
+   //    updatedFlags.willSave.value = actor.saves.will.dc.value;
+   //    // Repopulate other values as needed...
+   //
+   //    this.flags = updatedFlags;
+   //    if (this.actor.type === "npc")
+   //    {
+   //       this.actor.setFlag("fvtt-knowledge-recalled-pf2e", "npcFlags", this.flags)
+   //       .then(() => this.processValues())
+   //       .catch((error) => console.error("Failed to set flags:", error));
+   //    }
+   // }
+   //    else
+   //    {
+   //       this.initializeFlags();
+   //    }
+   // }
 }

--- a/src/models/NPCModel.js
+++ b/src/models/NPCModel.js
@@ -332,4 +332,19 @@ export default class NPCModel
 //          this.initializeFlags();
 //       }
 //    }
+
+   getData()
+   {
+      return {
+         baseCharacterInfo: {
+            name: this.actor.name,
+            creatureType: this.actor.system.details.creatureType,
+            alliance: this.actor.alliance,
+            actorImg: this.actor.img,
+            description: this.actor.description,
+            visibility: false,
+         },
+      }
+
+   }
 }

--- a/src/models/NPCModel.js
+++ b/src/models/NPCModel.js
@@ -66,7 +66,7 @@ export default class NPCModel
             CR: this.actor.level,
             visibility: false,
          },
-         traits: [],
+         traits: actor.traits,
          armorClass: {
             value: actor.attributes.ac.base,
             visibility: false,
@@ -288,49 +288,48 @@ export default class NPCModel
          console.error(`Invalid visibility property: ${propertyPath}`);
       }
    }
-   checkForChangesOnUpdate(actor)
-   {
-   const existingFlags = this.actor.getFlag("fvtt-knowledge-recalled-pf2e", "npcFlags");
-   if (existingFlags)
-   {
-      // Exclude visibility properties from the existingFlags object
-      const updatedFlags = Object.entries(existingFlags).reduce((flags, [key, value]) =>
-      {
-         if (!key.endsWith(".visibility"))
-         {
-            flags[key] = value;
-         }
-         return flags;
-      }, {});
-
-      // Repopulate the values that have path declarations
-      updatedFlags.baseCharacterInfo.name = actor.name;
-      updatedFlags.baseCharacterInfo.creatureType = actor.system.details.creatureType;
-      updatedFlags.baseCharacterInfo.alliance = actor.alliance;
-      updatedFlags.baseCharacterInfo.actorImg = actor.img;
-      updatedFlags.baseCharacterInfo.description = actor.description;
-      updatedFlags.rarity.value = actor.rarity;
-      updatedFlags.privateInfo.privateDescription = actor.system.details.privateNotes;
-      updatedFlags.privateInfo.CR = actor.level;
-      // need to do traits once this works
-
-      updatedFlags.armorClass.value = actor.attributes.ac.base;
-      updatedFlags.fortSave.value = actor.saves.fortitude.dc.value;
-      updatedFlags.refSave.value = actor.saves.reflex.dc.value;
-      updatedFlags.willSave.value = actor.saves.will.dc.value;
-      // Repopulate other values as needed...
-
-      this.flags = updatedFlags;
-      if (this.actor.type === "npc")
-      {
-         this.actor.setFlag("fvtt-knowledge-recalled-pf2e", "npcFlags", this.flags)
-         .then(() => this.processValues())
-         .catch((error) => console.error("Failed to set flags:", error));
-      }
-   }
-      else
-      {
-         this.initializeFlags();
-      }
-   }
+//    checkForChangesOnUpdate(actor) {
+//       const existingFlags = this.actor.getFlag("fvtt-knowledge-recalled-pf2e", "npcFlags");
+//       const updatedFlags = existingFlags ? { ...existingFlags } : {};
+//
+//       // Exclude visibility properties from the existingFlags object
+//       Object.entries(updatedFlags).forEach(([key, value]) =>
+// {
+//          if (key.endsWith(".visibility"))
+//          {
+//             delete updatedFlags[key];
+//          }
+//       });
+//
+//       // Repopulate the values that have path declarations
+//       updatedFlags.baseCharacterInfo = {
+//          name: actor.name,
+//          creatureType: actor.system.details.creatureType,
+//          alliance: actor.alliance,
+//          actorImg: actor.img,
+//          description: actor.description,
+//       };
+//       updatedFlags.rarity = { value: actor.rarity };
+//       updatedFlags.privateInfo = {
+//          privateDescription: actor.system.details.privateNotes,
+//          CR: actor.level,
+//       };
+//       // Update other values as needed...
+//       updatedFlags.armorClass = { value: actor.attributes.ac.base };
+//       updatedFlags.fortSave = { value: actor.saves.fortitude.dc.value };
+//       updatedFlags.refSave = { value: actor.saves.reflex.dc.value };
+//       updatedFlags.willSave = { value: actor.saves.will.dc.value };
+//       // Update other values as needed...
+//
+//       if (this.actor.type === "npc")
+//       {
+//          this.actor.setFlag("fvtt-knowledge-recalled-pf2e", "npcFlags", updatedFlags)
+//          .then(() => this.processValues())
+//          .catch((error) => console.error("Failed to set flags:", error));
+//       }
+//       else
+//       {
+//          this.initializeFlags();
+//       }
+//    }
 }

--- a/src/models/NPCModel.js
+++ b/src/models/NPCModel.js
@@ -273,12 +273,10 @@ export default class NPCModel
          this.actor.setFlag('fvtt-knowledge-recalled-pf2e',
           'npcFlags',
           this.flags
-         )
-         .then(() =>
+         ).then(() =>
          {
             console.log(`Visibility toggled successfully for property: ${propertyPath}`);
-         })
-         .catch((error) =>
+         }).catch((error) =>
          {
             console.error(`Failed to toggle visibility for property: ${propertyPath}`, error);
          });
@@ -288,6 +286,7 @@ export default class NPCModel
          console.error(`Invalid visibility property: ${propertyPath}`);
       }
    }
+
 //    checkForChangesOnUpdate(actor) {
 //       const existingFlags = this.actor.getFlag("fvtt-knowledge-recalled-pf2e", "npcFlags");
 //       const updatedFlags = existingFlags ? { ...existingFlags } : {};
@@ -344,7 +343,7 @@ export default class NPCModel
             description: this.actor.description,
             visibility: false,
          },
-      }
+      };
 
    }
 }


### PR DESCRIPTION
This will need to be reviewed.

checkForChangesOnUpdate(actor) function was indirectly triggering the update hook due to the call to this.actor.setFlag(). Each time the flags were updated, it triggered an update to the actor, which in turn called the updateNPCModelFlags(actor) function, creating an infinite loop.